### PR TITLE
Fix title text syntax highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,14 +1,14 @@
 id = "technique"
 name = "Technique"
 description = "Syntax highlighting for the Technique procedure language"
-version = "0.2.0"
+version = "0.2.1"
 schema_version = 1
 authors = ["Andrew Cowie"]
 repository = "https://github.com/technique-lang/extension.zed"
 
 [grammars.technique]
 repository = "https://github.com/technique-lang/tree-sitter-technique"
-commit = "2fef260f5aa7d141431790bb8d772b019806f657"
+commit = "784928d1bc1b0ba2488095dbe1916beb52c9e009"
 
 [language_servers.technique]
 name = "technique"


### PR DESCRIPTION
Update the Tree Sitter grammar to fix the title text of procedures not being syntax highlighted properly.