### PR TITLE
Place procedure names and titles in outline

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,14 +1,14 @@
 id = "technique"
 name = "Technique"
 description = "Syntax highlighting for the Technique procedure language"
-version = "0.2.1"
+version = "0.2.2"
 schema_version = 1
 authors = ["Andrew Cowie"]
 repository = "https://github.com/technique-lang/extension.zed"
 
 [grammars.technique]
 repository = "https://github.com/technique-lang/tree-sitter-technique"
-commit = "784928d1bc1b0ba2488095dbe1916beb52c9e009"
+commit = "5751f2748d1a587290f97ccad862aa50cb0c5aca"
 
 [language_servers.technique]
 name = "technique"

--- a/languages/technique/outline.scm
+++ b/languages/technique/outline.scm
@@ -1,0 +1,14 @@
+(procedure
+  (declaration
+    (procedure_name) @name
+    (declaration_marker) @context.extra
+    (signature)? @context.extra
+  )
+) @item
+
+(procedure
+  (title
+    (title_marker)
+    (title_text) @name 
+  )
+) @item


### PR DESCRIPTION
Add an "outline query" to the Zed Editor language extension, showing both procedure names and titles.

Getting titles nested under procedures was moderately tricky. Far harder was figuring out how to show which procedure we were in based on the user's cursor position.

This made us realize that the parse tree being generated by the Tree Sitter grammar was insufficient. We have long been unable to nest procedure content underneath a `(procedure)` node but this was lately addressed, which means that now not only does the newly added outline function, but when the user's cursor is somewhere in the body of a procedure that procedure name and title shows in the outline & breadcrumbs.