### PR TITLE
Implement labels for symbols

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "technique"
 name = "Technique"
 description = "Syntax highlighting for the Technique procedure language"
-version = "0.2.2"
+version = "0.2.3"
 schema_version = 1
 authors = ["Andrew Cowie"]
 repository = "https://github.com/technique-lang/extension.zed"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,32 +27,18 @@ impl zed::Extension for TechniqueExtension {
             SymbolKind::Constructor => {
                 let name = &symbol.name;
 
-                eprintln!("{:?}", name);
-
                 if let Some(pos) = name.find(" :") {
                     let procedure_name = &name[..pos];
-                    let signature = &name[pos + 2..]; // Skip " :"
-
-                    let mut spans = vec![
-                        // Procedure name with constructor highlight
-                        CodeLabelSpan::literal(procedure_name, Some("constructor".to_string())),
-                        CodeLabelSpan::literal(" ", None),
-                        CodeLabelSpan::literal(":", Some("punctuation.delimiter".to_string())),
-                    ];
-
-                    if signature.len() > 0 {
-                        let signature = &signature[1..]; // Skip " "
-
-                        spans.push(CodeLabelSpan::literal(" ", None));
-                        spans.push(CodeLabelSpan::literal(signature, Some("type".to_string())));
-                    }
 
                     Some(CodeLabel {
                         code: name.clone(),
-                        spans,
-                        filter_range: Range {
-                            start: 10,
+                        spans: vec![CodeLabelSpan::CodeRange(Range {
+                            start: 0,
                             end: name.len() as u32,
+                        })],
+                        filter_range: Range {
+                            start: 0,
+                            end: procedure_name.len() as u32,
                         },
                     })
                 } else {


### PR DESCRIPTION
A preliminary implementation of `label_for_symbol()` from the _Zed Extensions API_'s Extensions trait, showing symbols reported by the language server in project-wide symbol search, which at the moment is procedure names. Requires **technique** >= 0.4.6.